### PR TITLE
Add a way to preallocate memory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [compat]
 PrecompileTools = "1"

--- a/docs/src/internal.md
+++ b/docs/src/internal.md
@@ -1,7 +1,7 @@
-# Internal methods 
+# Internal methods
 
 ```@docs
-FiniteHorizonGramians._exp_and_gram_chol_init(A::AbstractMatrix{T}, B::AbstractMatrix{T}, method::ExpAndGram{T,q}) where {T,q}
+FiniteHorizonGramians._exp_and_gram_chol_init!(eA::AbstractMatrix{T}, eA::AbstractMatrix{T}, A::AbstractMatrix{T}, B::AbstractMatrix{T}, t::Number, method::ExpAndGram{T,q}) where {T,q}
 FiniteHorizonGramians._dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix)
 FiniteHorizonGramians.triu2cholesky_factor!(A::AbstractMatrix{T}) where {T<:Number}
 FiniteHorizonGramians._symmetrize!(A::AbstractMatrix{T}) where {T<:Number}

--- a/src/FiniteHorizonGramians.jl
+++ b/src/FiniteHorizonGramians.jl
@@ -2,6 +2,7 @@ module FiniteHorizonGramians
 
 using LinearAlgebra
 using PrecompileTools
+using SimpleUnPack
 
 include("utils.jl")
 

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -49,18 +49,24 @@ function exp_and_gram_chol!(
     method::AdaptiveExpAndGram,
     cache=alloc_mem(A, B, method)
 )
+    At, Bt = if cache == nothing
+        (copy(A) * t, copy(B) * sqrt(t))
+    else
+        (mul!(cache._A, A, t), mul!(cache._B, B, sqrt(t)))
+    end
+
     n, _ = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix)
 
     methods = method.methods
-    normA = opnorm(A, 1)
+    normAt = opnorm(At, 1)
 
-    if normA <= methods[1].normtol && n <= 4
+    if normAt <= methods[1].normtol && n <= 4
         Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[1], cache)
-    elseif normA <= methods[2].normtol && n <= 6
+    elseif normAt <= methods[2].normtol && n <= 6
         Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[2], cache)
-    elseif normA <= methods[3].normtol && n <= 8
+    elseif normAt <= methods[3].normtol && n <= 8
         Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[3], cache)
-    elseif normA <= methods[4].normtol && n <= 10
+    elseif normAt <= methods[4].normtol && n <= 10
         Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[4], cache)
     else
         Φ, U = exp_and_gram_chol!(eA, U, A, B, t, methods[5], cache)

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -39,6 +39,7 @@ function adaptive_to_alg(A, B, method::AdaptiveExpAndGram)
 end
 
 alloc_mem(A, B, method::AdaptiveExpAndGram) = alloc_mem(A, B, adaptive_to_alg(A, B, method))
+
 function exp_and_gram_chol!(
     eA::AbstractMatrix,
     U::AbstractMatrix,

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -20,25 +20,7 @@ struct AdaptiveExpAndGram{T,A} <: AbstractExpAndGramAlgorithm where {A}
     end
 end
 
-
-function adaptive_to_alg(A, B, method::AdaptiveExpAndGram)
-    n, _ = _dims_if_compatible(A, B)
-    methods = method.methods
-    normA = opnorm(A, 1)
-    if normA <= methods[1].normtol && n <= 4
-        return methods[1]
-    elseif normA <= methods[2].normtol && n <= 6
-        return methods[2]
-    elseif normA <= methods[3].normtol && n <= 8
-        return methods[3]
-    elseif normA <= methods[4].normtol && n <= 10
-        return methods[4]
-    else
-        return methods[5]
-    end
-end
-
-alloc_mem(A, B, method::AdaptiveExpAndGram) = alloc_mem(A, B, adaptive_to_alg(A, B, method))
+alloc_mem(A, B, method::AdaptiveExpAndGram) = nothing
 
 function exp_and_gram_chol!(
     eA::AbstractMatrix,
@@ -47,29 +29,25 @@ function exp_and_gram_chol!(
     B::AbstractMatrix,
     t::Real,
     method::AdaptiveExpAndGram,
-    cache=alloc_mem(A, B, method)
+    cache::Nothing=nothing,
 )
-    At, Bt = if cache == nothing
-        (copy(A) * t, copy(B) * sqrt(t))
-    else
-        (mul!(cache._A, A, t), mul!(cache._B, B, sqrt(t)))
-    end
+    At, Bt = copy(A) * t, copy(B) * sqrt(t)
 
-    n, _ = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix)
+    n, _ = _dims_if_compatible(At, Bt)
 
     methods = method.methods
     normAt = opnorm(At, 1)
 
     if normAt <= methods[1].normtol && n <= 4
-        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[1], cache)
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[1])
     elseif normAt <= methods[2].normtol && n <= 6
-        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[2], cache)
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[2])
     elseif normAt <= methods[3].normtol && n <= 8
-        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[3], cache)
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[3])
     elseif normAt <= methods[4].normtol && n <= 10
-        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[4], cache)
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[4])
     else
-        Φ, U = exp_and_gram_chol!(eA, U, A, B, t, methods[5], cache)
+        Φ, U = exp_and_gram_chol!(eA, U, A, B, t, methods[5])
     end
 
     return Φ, U

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -1,72 +1,68 @@
 """
     AdaptiveExpAndGram{T,A} <: AbstractExpAndGramAlgorithm
 
-Adaptive algorithm for computing the matrix exponential and an associated Gramian. 
+Adaptive algorithm for computing the matrix exponential and an associated Gramian.
 
-Constructor: 
+Constructor:
 
 AdaptiveExpAndGram{T}()
 
-creates an algorithm with coefficients stored in the numeric type T. 
+creates an algorithm with coefficients stored in the numeric type T.
 
 """
 struct AdaptiveExpAndGram{T,A} <: AbstractExpAndGramAlgorithm where {A}
     methods::A
+    function AdaptiveExpAndGram{T}() where {T}
+        methods = [ExpAndGram{T,q}() for q in (3, 5, 7, 9, 13)]
+        #normtols = T[0.00067, 0.021, 0.13, 0.41, 1.57] # normtols for Gramian
+        #normtols = T[0.0014, 0.25, 0.95, 2.1, 5.39] # normtols for matrix exponential
+        return new{T,typeof(methods)}(methods)
+    end
 end
 
-function AdaptiveExpAndGram{T}() where {T}
-    methods = [ExpAndGram{T,q}() for q in (3, 5, 7, 9, 13)]
-    #normtols = T[0.00067, 0.021, 0.13, 0.41, 1.57] # normtols for Gramian 
-    #normtols = T[0.0014, 0.25, 0.95, 2.1, 5.39] # normtols for matrix exponential 
-    return AdaptiveExpAndGram{T,typeof(methods)}(methods)
+
+function adaptive_to_alg(A, B, method::AdaptiveExpAndGram)
+    n, _ = _dims_if_compatible(A, B)
+    methods = method.methods
+    normA = opnorm(A, 1)
+    if normA <= methods[1].normtol && n <= 4
+        return methods[1]
+    elseif normA <= methods[2].normtol && n <= 6
+        return methods[2]
+    elseif normA <= methods[3].normtol && n <= 8
+        return methods[3]
+    elseif normA <= methods[4].normtol && n <= 10
+        return methods[4]
+    else
+        return methods[5]
+    end
 end
 
-function exp_and_gram(
-    A::AbstractMatrix{T},
-    B::AbstractMatrix{T},
-    method::AdaptiveExpAndGram,
-) where {T<:Number}
-    Φ, G = exp_and_gram!(copy(A), copy(B), method)
-    return Φ, G
-end
-
-function exp_and_gram!(
-    A::AbstractMatrix{T},
-    B::AbstractMatrix{T},
-    method::AdaptiveExpAndGram,
-) where {T<:Number}
-    Φ, U = exp_and_gram_chol!(A, B, method)
-    G = U' * U
-    _symmetrize!(G)
-    return Φ, G
-end
-
-exp_and_gram_chol(
-    A::AbstractMatrix{T},
-    B::AbstractMatrix{T},
-    method::AdaptiveExpAndGram{T},
-) where {T<:Number} = exp_and_gram_chol!(copy(A), copy(B), method)
-
+alloc_mem(A, B, method::AdaptiveExpAndGram) = alloc_mem(A, B, adaptive_to_alg(A, B, method))
 function exp_and_gram_chol!(
-    A::AbstractMatrix{T},
-    B::AbstractMatrix{T},
+    eA::AbstractMatrix,
+    U::AbstractMatrix,
+    A::AbstractMatrix,
+    B::AbstractMatrix,
+    t::Real,
     method::AdaptiveExpAndGram,
-) where {T<:Number}
+    cache=alloc_mem(A, B, method)
+)
     n, _ = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix)
 
     methods = method.methods
     normA = opnorm(A, 1)
 
     if normA <= methods[1].normtol && n <= 4
-        Φ, U = _exp_and_gram_chol_init(A, B, methods[1])
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[1], cache)
     elseif normA <= methods[2].normtol && n <= 6
-        Φ, U = _exp_and_gram_chol_init(A, B, methods[2])
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[2], cache)
     elseif normA <= methods[3].normtol && n <= 8
-        Φ, U = _exp_and_gram_chol_init(A, B, methods[3])
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[3], cache)
     elseif normA <= methods[4].normtol && n <= 10
-        Φ, U = _exp_and_gram_chol_init(A, B, methods[4])
+        Φ, U = _exp_and_gram_chol_init!(eA, U, A, B, t, methods[4], cache)
     else
-        Φ, U = exp_and_gram_chol!(A, B, methods[5])
+        Φ, U = exp_and_gram_chol!(eA, U, A, B, t, methods[5], cache)
     end
 
     return Φ, U

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -89,7 +89,7 @@ function exp_and_gram_chol!(
 
     # should pre-allocate here
     if s > 0
-        Φ, U = _exp_and_gram_double(Φ, U, si, cache)
+        Φ, U = _exp_and_gram_double!(Φ, U, si, cache)
     end
 
     triu2cholesky_factor!(U)
@@ -98,17 +98,15 @@ end
 
 
 # Note to self: This overwrites Φ0 but not U0
-prealloc_exp_and_gram_double(Φ, U0) = begin
-    m, n = size(U0)
-    return (U = similar(Φ),
-            pre_array = similar(Φ, 2n, n),
-            tmp = similar(Φ))
-end
-function _exp_and_gram_double!(Φ0, U0, s, cache=prealloc_exp_and_gram_double(Φ0, U0))
-    @unpack U, pre_array, tmp = cache
-
+function _exp_and_gram_double!(Φ0, U0, s, cache=nothing)
     Φ = Φ0
     m, n = size(U0)
+
+    if cache == nothing
+        cache = (U = similar(Φ0), pre_array = similar(Φ0, 2n, n), tmp = similar(Φ0))
+    end
+    @unpack U, pre_array, tmp = cache
+
     U[1:m, 1:n] .= U0
 
     for _ = 1:s

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -155,10 +155,10 @@ end
 
 
 """
-    _exp_and_gram_chol_init(A::AbstractMatrix{T}, B::AbstractMatrix{T}, L::LegendreExp{T})
+    _exp_and_gram_chol_init!(eA, U, A, B, t, method::ExpAndGram{T,q}, cache = alloc_mem(A, B, method))
 
-Computes the matrix exponential exp(A) and the controllability Grammian ∫_0^1 exp(A*t)*B*B'*exp(A'*t) dt,
-using a Legendre expansion of the matrix exponential.
+Computes the matrix exponential exp(A*t) and the controllability Grammian ∫_0^1 t*exp(A*t)*B*B'*exp(A'*t) dt
+and stores them in `eA` and `U`.
 """
 function _exp_and_gram_chol_init!(
     eA::AbstractMatrix{T},

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -41,12 +41,14 @@ exp_and_gram_chol(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
     method::ExpAndGram{T},
-) where {T<:Number} = exp_and_gram_chol!(copy(A), copy(B), method)
+    cache=alloc_mem(A, B, method),
+) where {T<:Number} = exp_and_gram_chol!(copy(A), copy(B), method, cache)
 
 function exp_and_gram_chol!(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
     method::ExpAndGram{T,q},
+    cache=alloc_mem(A, B, method)
 ) where {T<:Number,q}
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
@@ -61,7 +63,7 @@ function exp_and_gram_chol!(
         B ./= convert(T, sqrt(2^si))
     end
 
-    Φ, U = _exp_and_gram_chol_init(A, B, method)
+    Φ, U = _exp_and_gram_chol_init(A, B, method, cache)
 
     # should pre-allocate here
     if s > 0
@@ -106,6 +108,7 @@ function _exp_and_gram_chol_init(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
     method::ExpAndGram{T,q},
+    cache=alloc_mem(A, B, method),
 ) where {T,q}
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
@@ -174,6 +177,7 @@ function _exp_and_gram_chol_init(
     return expA, U
 end
 
+alloc_mem(A, B, method::ExpAndGram{T,q}) where {T,q} = nothing
 function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
     q = 13
     n, m = size(B)

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -37,6 +37,28 @@ function exp_and_gram!(
     return Φ, G
 end
 
+alloc_mem(A, B, method::ExpAndGram{T,q}) where {T,q} = nothing
+function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
+    q = 13
+    n, m = size(B)
+    return (
+        A2 = similar(A),
+        A4 = similar(A),
+        A6 = similar(A),
+        tmpA1 = similar(A),
+        tmpA2 = similar(A),
+        tmpA3 = similar(A),
+        L = similar(A, n, m * (q + 1)),
+        tmpB2 = similar(B),
+        A2B = similar(B),
+        A4B = similar(B),
+        A6B = similar(B),
+        U = similar(A),
+        pre_array = similar(A, 2n, n),
+        tmp = similar(A),
+    )
+end
+
 exp_and_gram_chol(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
@@ -181,28 +203,6 @@ function _exp_and_gram_chol_init(
     U = qr!(L').R # right Cholesky factor of the Grammian (may not be square!!)
     U = triu2cholesky_factor!(U)
     return expA, U
-end
-
-alloc_mem(A, B, method::ExpAndGram{T,q}) where {T,q} = nothing
-function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
-    q = 13
-    n, m = size(B)
-    return (
-        A2 = similar(A),
-        A4 = similar(A),
-        A6 = similar(A),
-        tmpA1 = similar(A),
-        tmpA2 = similar(A),
-        tmpA3 = similar(A),
-        L = similar(A, n, m * (q + 1)),
-        tmpB2 = similar(B),
-        A2B = similar(B),
-        A4B = similar(B),
-        A6B = similar(B),
-        U = similar(A),
-        pre_array = similar(A, 2n, n),
-        tmp = similar(A),
-    )
 end
 
 function _exp_and_gram_chol_init(

--- a/test/test_initial_approximations.jl
+++ b/test/test_initial_approximations.jl
@@ -12,7 +12,7 @@ function test_initial_approximation(T)
                 for ndiff = 1:deg
                     A, B = integrator2AB(T, ndiff)
                     Φgt, Ugt = integrator_exp_and_gram_chol(T, ndiff)
-                    Φ, U = FHG._exp_and_gram_chol_init(A, B, method)
+                    Φ, U = FHG._exp_and_gram_chol_init!(similar(A), similar(A), A, B, method)
 
                     @test Φ ≈ Φgt
                     @test Ugt ≈ U


### PR DESCRIPTION
Fixes #10

Currently only implemented for `ExpAndGram{T,13}`, so maybe I should add the others too