### PR TITLE
Second try: Add a way to preallocate memory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [compat]
 PrecompileTools = "1"

--- a/src/FiniteHorizonGramians.jl
+++ b/src/FiniteHorizonGramians.jl
@@ -2,6 +2,7 @@ module FiniteHorizonGramians
 
 using LinearAlgebra
 using PrecompileTools
+using SimpleUnPack
 
 include("utils.jl")
 

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -21,6 +21,8 @@ function AdaptiveExpAndGram{T}() where {T}
     return AdaptiveExpAndGram{T,typeof(methods)}(methods)
 end
 
+alloc_mem(A, B, method::AdaptiveExpAndGram) = nothing
+
 function exp_and_gram_chol!(
     eA::AbstractMatrix{T},
     _U::AbstractMatrix{T},

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -160,9 +160,11 @@ function exp_and_gram_chol!(
     method::ExpAndGram{T,q},
     cache = alloc_mem(A, B, method),
 ) where {T<:Number,q}
-
-    At = A * t
-    Bt = B * sqrt(t)
+    At, Bt = if cache == nothing
+        (A * t, B * sqrt(t))
+    else
+        (mul!(cache._A, A, t), mul!(cache._B, B, sqrt(t)))
+    end
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
     normA = opnorm(At, 1)

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -86,7 +86,8 @@ function exp_and_gram!(
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
     Φ, U = exp_and_gram_chol!(eA, U, A, B, method, cache)
-    G = U' * U
+    G = isnothing(cache) ? copy(U) : cache.U
+    mul!(G, U', U)
     _symmetrize!(G)
     return Φ, G
 end
@@ -101,7 +102,8 @@ function exp_and_gram!(
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
     Φ, U = exp_and_gram_chol!(eA, U, A, B, t, method, cache)
-    G = U' * U
+    G = isnothing(cache) ? copy(U) : cache.U
+    mul!(G, U', U)
     _symmetrize!(G)
     return Φ, G
 end

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -316,7 +316,8 @@ function _exp_and_gram_chol_init!(
     _U = triu2cholesky_factor!(_U)
 
     copy!(eA, expA)
-    copy!(U, _U)
+    U .= 0
+    copy!(view(U, 1:size(_U, 1), 1:size(_U, 2)), _U)
     return eA, U
 end
 
@@ -470,7 +471,8 @@ function _exp_and_gram_chol_init!(
     _U = triu2cholesky_factor!(_U)
 
     copy!(eA, expA)
-    copy!(U, _U)
+    U .= 0
+    copy!(view(U, 1:size(_U, 1), 1:size(_U, 2)), _U)
     return eA, U
 end
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -36,12 +36,14 @@ end
 
 function alloc_mem(A, B, method::ExpAndGram{T,q}) where {T,q}
     n, m = size(B)
-    # return (
-    #     U = similar(A),
-    #     pre_array = similar(A, 2n, n),
-    #     tmp = similar(A),
-    # )
-    return nothing
+    return (
+        U = similar(A),
+        pre_array = similar(A, 2n, n),
+        tmp = similar(A),
+        _A = similar(A),
+        _B = similar(B),
+        A2 = similar(A),
+    )
 end
 function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
     q = 13
@@ -193,13 +195,15 @@ end
 
 
 function _exp_and_gram_double!(Φ0, U0, s, cache)
-    Φ = Φ0
     m, n = size(U0)
-    U = similar(Φ)
+    if cache == nothing
+        cache = (U = similar(Φ0), pre_array = similar(Φ0, 2n, n), tmp = similar(Φ0))
+    end
+    @unpack U, pre_array, tmp = cache
+
+    Φ = Φ0
     U[1:m, 1:n] .= U0
 
-    pre_array = similar(Φ, 2n, n)
-    tmp = similar(Φ)
     for _ = 1:s
         sub_array = view(pre_array, 1:2m, 1:n)
         mul!(view(sub_array, 1:m, 1:n), view(U, 1:m, 1:n), Φ')

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -34,6 +34,38 @@ function exp_and_gram(
     return exp_and_gram!(similar(A), similar(A), copy(A), copy(B), t, method)
 end
 
+function alloc_mem(A, B, method::ExpAndGram{T,q}) where {T,q}
+    n, m = size(B)
+    # return (
+    #     U = similar(A),
+    #     pre_array = similar(A, 2n, n),
+    #     tmp = similar(A),
+    # )
+    return nothing
+end
+function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
+    q = 13
+    n, m = size(B)
+    return (
+        _A = similar(A),
+        _B = similar(B),
+        A2 = similar(A),
+        A4 = similar(A),
+        A6 = similar(A),
+        tmpA1 = similar(A),
+        tmpA2 = similar(A),
+        tmpA3 = similar(A),
+        L = similar(A, n, m * (q + 1)),
+        tmpB2 = similar(B),
+        A2B = similar(B),
+        A4B = similar(B),
+        A6B = similar(B),
+        U = similar(A),
+        pre_array = similar(A, 2n, n),
+        tmp = similar(A),
+    )
+end
+
 function exp_and_gram!(
     eA::AbstractMatrix{T},
     U::AbstractMatrix{T},

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -207,7 +207,7 @@ function _exp_and_gram_double!(Φ0, U0, s, cache)
     for _ = 1:s
         sub_array = view(pre_array, 1:2m, 1:n)
         mul!(view(sub_array, 1:m, 1:n), view(U, 1:m, 1:n), Φ')
-        sub_array[m+1:2m, 1:n] .= U[1:m, 1:n]
+        sub_array[m+1:2m, 1:n] .= @view U[1:m, 1:n]
         m = min(n, 2 * m) # new row-size of U
         U[1:m, 1:n] .= qr!(sub_array).R
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -74,7 +74,7 @@ function exp_and_gram!(
     method::AbstractExpAndGramAlgorithm,
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
-    Φ, U = exp_and_gram_chol!(eA, U, A, B, method)
+    Φ, U = exp_and_gram_chol!(eA, U, A, B, method, cache)
     G = U' * U
     _symmetrize!(G)
     return Φ, G
@@ -89,7 +89,7 @@ function exp_and_gram!(
     method::AbstractExpAndGramAlgorithm,
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
-    Φ, U = exp_and_gram_chol!(eA, U, A, B, t, method)
+    Φ, U = exp_and_gram_chol!(eA, U, A, B, t, method, cache)
     G = U' * U
     _symmetrize!(G)
     return Φ, G
@@ -101,18 +101,16 @@ exp_and_gram_chol(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
     method::AbstractExpAndGramAlgorithm,
-    cache = alloc_mem(A, B, method),
 ) where {T<:Number} =
-    exp_and_gram_chol!(similar(A), similar(A), copy(A), copy(B), method, cache)
+    exp_and_gram_chol!(similar(A), similar(A), copy(A), copy(B), method)
 
 exp_and_gram_chol(
     A::AbstractMatrix{T},
     B::AbstractMatrix{T},
     t::Number,
     method::AbstractExpAndGramAlgorithm,
-    cache = alloc_mem(A, B, method),
 ) where {T<:Number} =
-    exp_and_gram_chol!(similar(A), similar(A), copy(A), copy(B), t, method, cache)
+    exp_and_gram_chol!(similar(A), similar(A), copy(A), copy(B), t, method)
 
 
 """

--- a/test/test_initial_approximations.jl
+++ b/test/test_initial_approximations.jl
@@ -12,7 +12,7 @@ function test_initial_approximation(T)
                 for ndiff = 1:deg
                     A, B = integrator2AB(T, ndiff)
                     Φgt, Ugt = integrator_exp_and_gram_chol(T, ndiff)
-                    Φ, U = similar(A), similar(U)
+                    Φ, U = similar(A), similar(A)
                     _Φ, _U = FHG._exp_and_gram_chol_init!(Φ, U, A, B, method)
                     @test Φ ≈ _Φ
                     @test U ≈ _U

--- a/test/test_initial_approximations.jl
+++ b/test/test_initial_approximations.jl
@@ -12,8 +12,10 @@ function test_initial_approximation(T)
                 for ndiff = 1:deg
                     A, B = integrator2AB(T, ndiff)
                     Φgt, Ugt = integrator_exp_and_gram_chol(T, ndiff)
-                    Φ, U =
-                        FHG._exp_and_gram_chol_init!(similar(A), similar(A), A, B, method)
+                    Φ, U = similar(A), similar(U)
+                    _Φ, _U = FHG._exp_and_gram_chol_init!(Φ, U, A, B, method)
+                    @test Φ ≈ _Φ
+                    @test U ≈ _U
 
                     @test Φ ≈ Φgt
                     @test Ugt ≈ U


### PR DESCRIPTION
Replaces #11; implements #10.

Functions to check for things that could be preallocated:
- [x] `_exp_and_gram_chol_init!` for `ExpAndGram{T,13}`
- [x] `_exp_and_gram_chol_init!` for `ExpAndGram{T,q}`
- [x] `_exp_and_gram_double!`
- [x] `exp_and_gram_chol!` for `ExpAndGram{T,q}`

This PR does _not_ implement preallocation for the `AdaptiveExpAndGram` algorithm!
