### PR TITLE
Simplify cache

### DIFF
--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -299,7 +299,7 @@ function _exp_and_gram_chol_init!(
 
     odd = mul!(tmpA1, A, odd)
     den = tmpA2 .= even .- odd # pade denominator
-    eA .= even .+ odd # pade numerator
+    @. eA = even + odd # pade numerator
 
     Lodd .= mul!(Loddtmp, A, Lodd) # writes into L as Lodd and L share memory
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -312,7 +312,7 @@ function _exp_and_gram_chol_init!(
     thinU = qr!(L').R # right Cholesky factor of the Grammian (may not be square!!)
     thinU = triu2cholesky_factor!(thinU)
 
-    U .= 0
+    fill!(U, zero(eltype(U)))
     copy!(view(U, 1:size(thinU, 1), 1:size(thinU, 2)), thinU)
     return eA, U
 end
@@ -462,7 +462,7 @@ function _exp_and_gram_chol_init!(
     _U = triu2cholesky_factor!(_U)
 
     copy!(eA, expA)
-    U .= 0
+    fill!(U, zero(eltype(U)))
     copy!(view(U, 1:size(_U, 1), 1:size(_U, 2)), _U)
     return eA, U
 end

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -326,12 +326,7 @@ function _exp_and_gram_chol_init!(
 ) where {T}
     @unpack A2, A4, A6, tmpA1, tmpA2, tmpA3, L, tmpB2, A2B, A4B, A6B = cache
 
-    n, m = size(B)
-    n == LinearAlgebra.checksquare(A) || throw(
-        DimensionMismatch(
-            "size of A, $(LinearAlgebra.checksquare(A)), incompatible with the size of B, $(size(B)).",
-        ),
-    )
+    n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
 
     # fetch expansion coefficients
     pade_num = method.pade_num

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -44,7 +44,7 @@ function alloc_mem(A, B, ::ExpAndGram{T,q}) where {T,q}
         A2 = similar(A),
         odd = similar(A),
         even = similar(A),
-        tmpA1 = similar(A),
+        tmpA = similar(A),
         L = zeros(eltype(A), n, m * (q + 1)),
     )
 end
@@ -235,7 +235,7 @@ function _exp_and_gram_chol_init!(
     method::ExpAndGram{T,q},
     cache = alloc_mem(A, B, method),
 ) where {T,q}
-    @unpack P, A2, L, tmpA1, odd, even = cache
+    @unpack P, A2, L, tmpA, odd, even = cache
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
     isodd(q) || throw(DomainError(q, "The degree $(q) must be odd")) # code heavily assumes odd degree expansion
@@ -277,8 +277,8 @@ function _exp_and_gram_chol_init!(
     mul!(L3, P, B, gram_coeffs[4, 4], true)
 
     for k = 2:(div(length(pade_num), 2)-1)
-        mul!(tmpA1, P, A2)
-        copy!(P, tmpA1)
+        mul!(tmpA, P, A2)
+        copy!(P, tmpA)
         mul!(even, pade_num[2k+1], P, true, true)
         mul!(odd, pade_num[2k+2], P, true, true)
 
@@ -291,10 +291,10 @@ function _exp_and_gram_chol_init!(
         end
     end
 
-    mul!(tmpA1, A, odd)
-    odd, tmpA1 = tmpA1, odd # equivalent to A * odd
+    mul!(tmpA, A, odd)
+    odd, tmpA = tmpA, odd # equivalent to A * odd
 
-    den = tmpA1
+    den = tmpA
     @. den = even - odd # pade denominator
     @. eA = even + odd # pade numerator
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -38,8 +38,8 @@ function alloc_mem(A, B, ::ExpAndGram{T,q}) where {T,q}
     n, m = size(B)
     return (
         pre_array = similar(A, 2n, n),
-        _A = similar(A),
-        _B = similar(B),
+        At = similar(A),
+        Bt = similar(B),
         odd = similar(A),
         even = similar(A),
         tmpA = similar(A),
@@ -50,8 +50,8 @@ function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
     q = 13
     n, m = size(B)
     return (
-        _A = similar(A),
-        _B = similar(B),
+        At = similar(A),
+        Bt = similar(B),
         A2 = similar(A),
         A4 = similar(A),
         A6 = similar(A),
@@ -75,7 +75,7 @@ function exp_and_gram!(
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
     Φ, U = exp_and_gram_chol!(eA, U, A, B, method, cache)
-    G = isnothing(cache) ? copy(U) : cache._A
+    G = isnothing(cache) ? copy(U) : cache.At
     mul!(G, U', U)
     _symmetrize!(G)
     return Φ, G
@@ -91,7 +91,7 @@ function exp_and_gram!(
     cache = alloc_mem(A, B, method),
 ) where {T<:Number}
     Φ, U = exp_and_gram_chol!(eA, U, A, B, t, method, cache)
-    G = isnothing(cache) ? copy(U) : cache._A
+    G = isnothing(cache) ? copy(U) : cache.At
     mul!(G, U', U)
     _symmetrize!(G)
     return Φ, G
@@ -165,7 +165,7 @@ function exp_and_gram_chol!(
     At, Bt = if cache == nothing
         (A * t, B * sqrt(t))
     else
-        (mul!(cache._A, A, t), mul!(cache._B, B, sqrt(t)))
+        (mul!(cache.At, A, t), mul!(cache.Bt, B, sqrt(t)))
     end
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -40,8 +40,6 @@ function alloc_mem(A, B, ::ExpAndGram{T,q}) where {T,q}
         pre_array = similar(A, 2n, n),
         _A = similar(A),
         _B = similar(B),
-        P = similar(A),
-        A2 = similar(A),
         odd = similar(A),
         even = similar(A),
         tmpA = similar(A),
@@ -235,7 +233,7 @@ function _exp_and_gram_chol_init!(
     method::ExpAndGram{T,q},
     cache = alloc_mem(A, B, method),
 ) where {T,q}
-    @unpack P, A2, L, tmpA, odd, even = cache
+    @unpack L, tmpA, odd, even = cache
 
     n, m = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix) # first checks that (A, B) have compatible dimensions
     isodd(q) || throw(DomainError(q, "The degree $(q) must be odd")) # code heavily assumes odd degree expansion
@@ -245,6 +243,8 @@ function _exp_and_gram_chol_init!(
     gram_coeffs = method.gram_coeffs
     ncoeffhalf = div(q + 1, 2)
 
+    A2 = eA # A2 is used to increment the power of A in P, we can use eA for this
+    P = U # P is used to iterate through even powers of A, we can use U for this
     mul!(A2, A, A)
     copy!(P, A2)
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -39,7 +39,6 @@ function alloc_mem(A, B, ::ExpAndGram{T,q}) where {T,q}
     ncoeffhalf = div(q + 1, 2)
     return (
         pre_array = similar(A, 2n, n),
-        tmp = similar(A),
         _A = similar(A),
         _B = similar(B),
         P = similar(A),
@@ -70,7 +69,6 @@ function alloc_mem(A, B, method::ExpAndGram{T,13}) where {T}
         A4B = similar(B),
         A6B = similar(B),
         pre_array = similar(A, 2n, n),
-        tmp = similar(A),
     )
 end
 

--- a/src/exp_and_gram.jl
+++ b/src/exp_and_gram.jl
@@ -206,7 +206,7 @@ end
 function _exp_and_gram_double!(eA, U, s, cache)
     n = LinearAlgebra.checksquare(U)
     if isnothing(cache)
-        cache = (pre_array = similar(U, 2n, n), tmp = similar(Φ0))
+        cache = (pre_array = similar(U, 2n, n),)
     end
     @unpack pre_array = cache
 


### PR DESCRIPTION

* Giving some cache variables more sensible names 
* Removing unnecessary elements from the cache. 

Benchmark results: 

Before: 
```julia
[ Info: Benchmark: cache creation
[ Info: low order
  1.137 μs (16 allocations: 37.38 KiB)
[ Info: high order (q = 13)
  2.786 μs (18 allocations: 39.14 KiB)


[ Info: Benchnmark: function exection no cache / cache
[ Info: order = 3
  294.004 μs (71 allocations: 204.11 KiB)
  289.479 μs (54 allocations: 157.19 KiB)
[ Info: order = 5
  209.476 μs (59 allocations: 156.36 KiB)
  204.948 μs (42 allocations: 108.95 KiB)
[ Info: order = 7
  176.756 μs (53 allocations: 137.59 KiB)
  172.087 μs (36 allocations: 89.73 KiB)
[ Info: order = 9
  144.638 μs (47 allocations: 119.14 KiB)
  140.253 μs (30 allocations: 70.69 KiB)
[ Info: order = 13
  109.732 μs (37 allocations: 97.20 KiB)
  105.795 μs (18 allocations: 51.45 KiB)
```

After: 

```julia
[ Info: Benchmark: cache creation
[ Info: low order
  708.119 ns (10 allocations: 20.73 KiB)
[ Info: high order (q = 13)
  2.544 μs (16 allocations: 32.64 KiB)


[ Info: Benchnmark: function exection no cache / cache
[ Info: order = 3
  292.531 μs (65 allocations: 187.47 KiB)
  290.586 μs (54 allocations: 157.19 KiB)
[ Info: order = 5
  208.147 μs (53 allocations: 139.58 KiB)
  205.640 μs (42 allocations: 108.95 KiB)
[ Info: order = 7
  175.723 μs (47 allocations: 120.62 KiB)
  173.910 μs (36 allocations: 89.73 KiB)
[ Info: order = 9
  143.843 μs (41 allocations: 102.02 KiB)
  141.156 μs (30 allocations: 70.69 KiB)
[ Info: order = 13
  109.445 μs (35 allocations: 90.70 KiB)
  105.679 μs (18 allocations: 51.45 KiB)
```

Benchmark script:

```julia
using FiniteHorizonGramians, BenchmarkTools

λ = 1.0
n = 20
t = 1.0
A = λ * (I - 2 * tril(ones(n, n)))
B = sqrt(2λ) * ones(n, 1)
eA = similar(A)
U = similar(A)

qs = [3, 5, 7, 9, 13]

methods = [ExpAndGram{Float64,q}() for q in qs]
caches = [FiniteHorizonGramians.alloc_mem(A, B, method) for method in methods]

order(::ExpAndGram{T,Q}) where {T,Q} = Q

@info "Benchmark: cache creation"
@info "low order"
@btime FiniteHorizonGramians.alloc_mem($A, $B, ExpAndGram{Float64,3}())
@info "high order (q = 13)"
@btime FiniteHorizonGramians.alloc_mem($A, $B, ExpAndGram{Float64,13}())

println("\n")

@info "Benchnmark: function exection no cache / cache"
for (method, cache) in zip(methods, caches)
    @info "order = $(order(method))"
    @btime exp_and_gram_chol($A, $B, $t, $method)
    @btime exp_and_gram_chol!($eA, $U, $A, $B, $t, $method, $cache)
end

```