### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,23 @@
 [![Build Status](https://github.com/filtron/FiniteHorizonGramians.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/filtron/FiniteHorizonGramians.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/filtron/FiniteHorizonGramians.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/filtron/FiniteHorizonGramians.jl)
 
-Associated with the pair of matrices $A \in \mathbb{R}^{n \times n}$ and $B \in \mathbb{R}^{n \times m}$ is the finite horizon controllability Gramian over the unit interval
+## Introduction 
+
+Associated with the pair of matrices $A \in \mathbb{R}^{n \times n}$ and $B \in \mathbb{R}^{n \times m}$ is the differential Lyapunov equation: 
+
+$$
+\dot{Q}(\tau) = A Q(\tau) + Q(\tau) A^* + B B^*, \quad Q(0) = 0,\quad \tau \in [0, t].
+$$
+
+$Q(t)$ is the finite Horizon controllability Gramian of $(A, B)$, over the interval $[0, t]$, 
+and may be equivalently expressed by the function $Q(t) = G(At, B \sqrt{t})$, where 
 
 $$
 G(A, B) = \int_0^1 e^{A t} B B^* e^{A^* t} \mathrm{d} t.
 $$
 
-The Gramian, $G(A, B)$, is positive semi-definite and therefore has an upper triangular Cholesky factor, $U(A, B)$,
-such that $G(A, B) = U^*(A, B) U(A, B)$.
-This package provides algorithms for computing both the matrix exponential, $e^A$, and the Cholesky factor, $U(A, B)$,
+The Gramian, $G(A, B)$, is positive semi-definite and therefore has an upper triangular Cholesky factor, $U(A, B)$.
+This package provides algorithms for computing both $e^A$ and $U(A, B)$,
 without having to form $G(A, B)$ as an intermediate step.
 This avoids the problem of failing Cholesky factorization when computing $G(A, B)$ directly leads to a numerically non-positive definite matrix.
 
@@ -31,7 +39,7 @@ $$
 p(t + h, x \mid t, x') = \mathcal{N}\big(x; e^{A h} x', G(A h, \sqrt{h} B) \big).
 $$
 
-Consequently this package offers a method to both compute the transition matrix $e^{A h}$ and a Cholesky factor of $G(A h, \sqrt{h} B)$ in a numerically robust way.
+This package offers a method to both compute the transition matrix $e^{A h}$ and a Cholesky factor of $G(A h, \sqrt{h} B)$ in a numerically robust way.
 This is useful for instance in so called array implementations of Gauss-Markov regression (i.e. square-root Kalman filters etc).
 
 ## Installation
@@ -43,14 +51,25 @@ This is useful for instance in so called array implementations of Gauss-Markov r
 ## Basic usage
 
 ```julia
-A = [0.0 0.0; 1.0 0.0]
-B = [1.0; 0.0;;]
+using FiniteHorizonGramians, LinearAlgebra
 
-method = AdaptiveExpAndGram{Float64}()
-expA, U = exp_and_gram_chol(A, B, method)
-_, G = exp_and_gram(A, B, method)
+n = 15
+A = (I - 2.0 * tril(ones(n, n)))
+B = sqrt(2.0) * ones(n, 1)
+ts = LinRange(0.0, 1.0, 2^3)
 
-G ≈ U' * U # returns true
+method = ExpAndGram{Float64,13}()
+cache = FiniteHorizonGramians.alloc_mem(A, B, method) # allocate memory for intermediate calculations
+eA, U = similar(A), similar(A) # allocate memory for outputs
+
+for t in ts
+   exp_and_gram_chol!(eA, U, A, B, t, method, cache)
+    # do cool stuff with eA and U here?
+end
+
+eA, G = exp_and_gram!(eA, similar(U), A, B, last(ts), method, cache) # we can comput the full Gramian if we prefer
+G ≈ U'U # true
+eA ≈ exp(A * last(ts)) # we also get an accurate matrix exponential, of course.
 ```
 
 ## Related packages

--- a/test/test_exp_and_gram.jl
+++ b/test/test_exp_and_gram.jl
@@ -9,8 +9,9 @@ function test_exp_and_gram(T)
     ts = [0.5, 1.0, 1.5]
 
     qs = [3, 5, 7, 9, 13]
+    tols = [1e-10, 1e-11, 1e-11, 1e-11, 1e-11] # method 3 is quite inaccurate due to the doubling shenanigans...
 
-    for q in qs
+    for (i, q) in enumerate(qs)
 
         method = ExpAndGram{T,q}()
 
@@ -20,12 +21,12 @@ function test_exp_and_gram(T)
             for t in ts
                 Φgt, Ggt = mf_exp_and_gram(A, B, t)
                 Φ, G = exp_and_gram(A, B, t, method)
-                @test isapprox(err(Φ, Φgt), zero(T), atol = tol)
-                @test isapprox(err(G, Ggt), zero(T), atol = tol)
+                @test isapprox(err(Φ, Φgt), zero(T), atol = tols[i])
+                @test isapprox(err(G, Ggt), zero(T), atol = tols[i])
             end
             Φgt, Ggt = mf_exp_and_gram(A, B)
             Φ, G = exp_and_gram(A, B, method)
-            @test isapprox(err(G, Ggt), zero(T), atol = tol)
+            @test isapprox(err(G, Ggt), zero(T), atol = tols[i])
         end
 
         @testset "q = $(q) | exp_and_gram_chol" begin
@@ -34,14 +35,14 @@ function test_exp_and_gram(T)
                 Φ, U = exp_and_gram_chol(A, B, t, method)
                 G = U'*U
                 FHG._symmetrize!(G)
-                @test isapprox(err(Φ, Φgt), zero(T), atol = tol)
-                @test isapprox(err(G, Ggt), zero(T), atol = tol)
+                @test isapprox(err(Φ, Φgt), zero(T), atol = tols[i])
+                @test isapprox(err(G, Ggt), zero(T), atol = tols[i])
             end
             Φgt, Ggt = mf_exp_and_gram(A, B)
             Φ, U = exp_and_gram_chol(A, B, method)
             G = U'*U
             FHG._symmetrize!(G)
-            @test isapprox(err(G, Ggt), zero(T), atol = tol)
+            @test isapprox(err(G, Ggt), zero(T), atol = tols[i])
         end
 
         @testset "q = $(q) | on-square initial Gramian" begin


### PR DESCRIPTION
Basic usage now includes pre-allocation and using ```ExpAndGram{T,13}```, which I would recommend as default. 