### PR TITLE
vector valued B 

### DIFF
--- a/docs/src/public.md
+++ b/docs/src/public.md
@@ -8,7 +8,7 @@ ExpAndGram{T,N,A,B,C}
 ## Create cache
 
 ```@docs
-FiniteHorizonGramians.alloc_mem(A, B, ::ExpAndGram{T,q}) where {T,q}
+FiniteHorizonGramians.alloc_mem(A, B::AbstractMatrix, ::ExpAndGram{T,q}) where {T,q}
 ```
 
 

--- a/src/FiniteHorizonGramians.jl
+++ b/src/FiniteHorizonGramians.jl
@@ -14,8 +14,8 @@ export AbstractExpAndGramAlgorithm
 """
     exp_and_gram(
         A::AbstractMatrix{T},
-        B::AbstractMatrix{T},
-        t::Number,
+        B::AbstractVecOrMat{T},
+        [t::Number],
         method::AbstractExpAndGramAlgorithm,
     )
 
@@ -27,7 +27,7 @@ function exp_and_gram end
 """
     exp_and_gram_chol(
         A::AbstractMatrix{T},
-        B::AbstractMatrix{T},
+        B::AbstractVecOrMat{T},
         [t::Number],
         method::AbstractExpAndGramAlgorithm,
     )
@@ -42,8 +42,8 @@ function exp_and_gram_chol end
         eA::AbstractMatrix{T},
         G::AbstractMatrix{T},
         A::AbstractMatrix{T},
-        B::AbstractMatrix{T},
-        t::Number,
+        B::AbstractVecOrMat{T},
+        [t::Number],
         method::AbstractExpAndGramAlgorithm,
         cache = alloc_mem(A, B, method),
     )
@@ -59,7 +59,7 @@ function exp_and_gram! end
         eA::AbstractMatrix{T},
         U::AbstractMatrix{T},
         A::AbstractMatrix{T},
-        B::AbstractMatrix{T},
+        B::AbstractVecOrMat{T},
         [t::Number],
         method::ExpAndGram{T,q},
         [cache = alloc_mem(A, B, method)],
@@ -69,7 +69,7 @@ function exp_and_gram! end
         eA::AbstractMatrix{T},
         U::AbstractMatrix{T},
         A::AbstractMatrix{T},
-        B::AbstractMatrix{T},
+        B::AbstractVecOrMat{T},
         [t::Number],
         method::AdaptiveExpAndGram,
         [cache = nothing],

--- a/src/FiniteHorizonGramians.jl
+++ b/src/FiniteHorizonGramians.jl
@@ -92,12 +92,15 @@ export ExpAndGram, AdaptiveExpAndGram
 
 Computes an estimate of the condition number of the controllability Gramian of (A, B) on the interval [0, 1] with respect to the 2-norm.
 """
-function gramcond(A, B)
+function gramcond(A::AbstractMatrix, B::AbstractMatrix)
     T = promote_type(eltype(A), eltype(B))
     R = real(T)
     gcond = R(2) * (one(R) + one(R) / opnorm(B, 2)) * (opnorm(A, 2) + opnorm(B, 2))
     return gcond
 end
+
+gramcond(A::AbstractMatrix, B::AbstractVector) = gramcond(A, reshape(B, length(B), 1))
+
 
 export gramcond
 

--- a/src/adaptive_exp_and_gram.jl
+++ b/src/adaptive_exp_and_gram.jl
@@ -22,6 +22,8 @@ function AdaptiveExpAndGram{T}() where {T}
 end
 
 alloc_mem(A, B, method::AdaptiveExpAndGram) = nothing
+alloc_mem(A, B::AbstractVector, alg::AdaptiveExpAndGram) = nothing # needed to disambiguate
+
 
 function exp_and_gram_chol!(
     eA::AbstractMatrix{T},
@@ -32,7 +34,7 @@ function exp_and_gram_chol!(
     method::AdaptiveExpAndGram,
     cache = nothing,
 ) where {T<:Number}
-    n, _ = _dims_if_compatible(A::AbstractMatrix, B::AbstractMatrix)
+    n, _ = _dims_if_compatible(A, B)
 
     At = A * T(t)
     Bt = B * T(sqrt(t))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,10 @@ numeric_types = (Float32, Float64, ComplexF32, ComplexF64)
         end
     end
 
+    @testset "gramcond" begin
+        include("test_gramcond.jl")
+    end
+
     @testset "autodiff" begin
         test_ForwardDiff()
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("test_utils.jl")
 include("test_initial_approximations.jl")
 include("test_exp_and_gram.jl")
 include("test_adaptive_exp_and_gram.jl")
+include("test_vector_valued_B.jl")
 include("test_autodiff.jl")
 
 numeric_types = (Float32, Float64, ComplexF32, ComplexF64)
@@ -26,10 +27,15 @@ numeric_types = (Float32, Float64, ComplexF32, ComplexF64)
         end
     end
 
-
     @testset "adaptive algorithm" begin
         for T in numeric_types
             test_adaptive_exp_and_gram(T)
+        end
+    end
+
+    @testset "vector-valued B" begin
+        for T in numeric_types
+            test_vector_valued_B(T)
         end
     end
 

--- a/test/test_gramcond.jl
+++ b/test/test_gramcond.jl
@@ -1,0 +1,13 @@
+numeric_types = (Float32, Float64, ComplexF32, ComplexF64)
+n = 5
+
+for T in numeric_types
+    A = (I - T(2) * tril(ones(T, n, n)))
+    B = sqrt(T(2)) * ones(T, n, 1)
+    Bvec = vec(B)
+    R = real(T)
+
+    @test gramcond(A, B) ≈
+          gramcond(A, Bvec) ≈
+          R(2) * (one(R) + one(R) / opnorm(B, 2)) * (opnorm(A, 2) + opnorm(B, 2))
+end

--- a/test/test_vector_valued_B.jl
+++ b/test/test_vector_valued_B.jl
@@ -1,0 +1,45 @@
+function test_vector_valued_B(T)
+
+    n = 5
+    A = (I - T(2) * tril(ones(T, n, n)))
+    B = sqrt(T(2)) * ones(T, n, 1)
+    Bvec = vec(B)
+    t = one(T)
+
+    algs = [ExpAndGram{T,q}() for q in [3, 5, 7, 9, 13]]
+    algs = vcat(algs, AdaptiveExpAndGram{T}())
+
+    for alg in algs
+
+        # non-mutating gram
+        @test all(exp_and_gram(A, B, alg) .≈ exp_and_gram(A, Bvec, alg))
+        @test all(exp_and_gram(A, B, t, alg) .≈ exp_and_gram(A, Bvec, t, alg))
+
+        # mutating gram
+        @test all(
+            exp_and_gram!(similar(A), similar(A), A, B, alg) .≈
+            exp_and_gram!(similar(A), similar(A), A, Bvec, alg),
+        )
+        @test all(
+            exp_and_gram!(similar(A), similar(A), A, B, t, alg) .≈
+            exp_and_gram!(similar(A), similar(A), A, Bvec, t, alg),
+        )
+
+        # non-mutating chol
+        @test all(exp_and_gram_chol(A, B, alg) .≈ exp_and_gram_chol(A, Bvec, alg))
+        @test all(exp_and_gram_chol(A, B, t, alg) .≈ exp_and_gram_chol(A, Bvec, t, alg))
+
+        # mutating chol
+        @test all(
+            exp_and_gram_chol!(similar(A), similar(A), A, B, alg) .≈
+            exp_and_gram_chol!(similar(A), similar(A), A, Bvec, alg),
+        )
+        @test all(
+            exp_and_gram_chol!(similar(A), similar(A), A, B, t, alg) .≈
+            exp_and_gram_chol!(similar(A), similar(A), A, Bvec, t, alg),
+        )
+
+    end
+
+
+end


### PR DESCRIPTION
Fixes #29 

The strategy is to add methods with signature where ```B::AbstractVector``` that call the original routines with```reshape(B, length(B), 1)```. It might not be the most efficient implementation, but it works. 